### PR TITLE
Fix deprecated function

### DIFF
--- a/sideline-eglot.el
+++ b/sideline-eglot.el
@@ -38,6 +38,8 @@
 (require 'eglot)
 (require 'sideline)
 
+(declare-function eglot-execute "eglot")
+
 (defgroup sideline-eglot nil
   "Show eglot information with sideline."
   :prefix "sideline-eglot-"

--- a/sideline-eglot.el
+++ b/sideline-eglot.el
@@ -109,9 +109,7 @@ Argument COMMAND is required in sideline backend."
             (command (cl-getf matching-code-action :command))
             (server (eglot-current-server)))
          (sideline-eglot--inhibit-timeout
-           (eglot-execute-command server
-                                  (cl-getf command :command)
-                                  (cl-getf command :arguments))))))))
+           (eglot-execute server command)))))))
 
 (provide 'sideline-eglot)
 ;;; sideline-eglot.el ends here

--- a/sideline-eglot.el
+++ b/sideline-eglot.el
@@ -109,7 +109,11 @@ Argument COMMAND is required in sideline backend."
             (command (cl-getf matching-code-action :command))
             (server (eglot-current-server)))
          (sideline-eglot--inhibit-timeout
-           (eglot-execute server command)))))))
+          (if (fboundp #'eglot-execute)
+              (eglot-execute server command)
+            (eglot-execute-command server
+                                   (cl-getf command :command)
+                                   (cl-getf command :arguments)))))))))
 
 (provide 'sideline-eglot)
 ;;; sideline-eglot.el ends here


### PR DESCRIPTION
In Emacs 30.x eglot-execute-command is deprecated,
this patch fix this using eglot-execute instead.
