### PR TITLE
Fix applying code action so it works with an inline edit

### DIFF
--- a/sideline-eglot.el
+++ b/sideline-eglot.el
@@ -118,14 +118,15 @@ Argument COMMAND is required in sideline backend."
      (lambda (candidate &rest _)
        (when-let*
            ((matching-code-action (ht-get sideline-eglot--ht-candidates candidate))
-            (command (cl-getf matching-code-action :command))
             (server (eglot-current-server)))
          (sideline-eglot--inhibit-timeout
            (if (fboundp #'eglot-execute)
-               (eglot-execute server command)
-             (eglot-execute-command server
-                                    (cl-getf command :command)
-                                    (cl-getf command :arguments)))))))))
+               (eglot-execute server matching-code-action)
+             (when-let*
+                 ((command (cl-getf matching-code-action :command)))
+               (eglot-execute-command server
+                                      (cl-getf command :command)
+                                      (cl-getf command :arguments))))))))))
 
 (provide 'sideline-eglot)
 ;;; sideline-eglot.el ends here


### PR DESCRIPTION
Some language servers provide a code action with an edit included in it, rather than a command.  This can be handled cleanly by `eglot-execute`.

So update the action to not require a `:command` argument unless `eglot-execute` is not bound, and to pass the entire `matching-code-action` to `eglot-execute`, as it can handle both cases.